### PR TITLE
Add upstream_package_name to packit conf

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,3 +3,4 @@ specfile_path: tmux-top.spec
 synced_files:
   - tmux-top.spec
 downstream_package_name: tmux-top
+upstream_package_name: tmux-top


### PR DESCRIPTION
Found while srpm building during onboarding:
```
"upstream_package_name" is not set: unable to fix the spec file; please set it.
```

I'd add copr enable in another PR, this repo seems as a good guinea pig for onboarding script.